### PR TITLE
Update README to mention text based installer

### DIFF
--- a/README
+++ b/README
@@ -27,7 +27,7 @@ How to use
 -----------------------------------------------------------------------
 1) Download the already setup jar at https://github.com/downloads/dcepler/unofficial-updater2/Unofficial-Updater2.jar
 2) Stop the server you are going to update
-3) Run the command "java -jar Unofficial-Updater2.jar"
+3) Run the command "java -jar Unofficial-Updater2.jar" (for GUI installer) or "java -jar Unofficial-Updater2.jar text" (for text based installer)
 4) Walk through the screens putting the appropriate information
   4.1) **Be sure to fill CFIDE directory location** else you will get a weird error message on "Next"
 5) Finish updater by pressing "Apply Updates"


### PR DESCRIPTION
I made a minor change to the readme to include information about the command required to launch the text based installer.  Please consider this for inclusion.
