### PR TITLE
Adobe relocated some of its hotfix downloads

### DIFF
--- a/cf_hotfixes.properties
+++ b/cf_hotfixes.properties
@@ -22,34 +22,34 @@ kb403795.files=hf801-70839.zip
 kb403795.hf801-70839.zip.sha-512=1c0a3bbc9602b71ed440dac4b8586c9cd222296996651b6d604581f096c6cb1bde60cf97467e412e723db0afc73fa5fd15e9de25dd1aa3f6468ded8427825895
 
 cpsid_52915.description=Cumulative Hot Fix 4 (CHF4) for ColdFusion 8.0.1
-cpsid_52915.url=http://kb2.adobe.com/cps/529/cpsid_52915/attachments/
+cpsid_52915.url=http://helpx.adobe.com/content/dam/kb/en/529/cpsid_52915/attachments/
 cpsid_52915.files=chf8010004.zip
 cpsid_52915.chf8010004.zip.sha-512=a807730569b0238171e8bca1cf4e1192b4e4f94c82e19153280c589ac8f346232de07d57345ddb1bcebb8b4eb1114d6c35fd1894cece79337cdbd5889033e345
 
 cpsid_84585.description=Update for expired certificate on CFForm controls for ColdFusion 8.0.1 (May 2010)
-cpsid_84585.url=http://kb2.adobe.com/cps/845/cpsid_84585/attachments/
+cpsid_84585.url=http://helpx.adobe.com/content/dam/kb/en/845/cpsid_84585/attachments/
 cpsid_84585.files=cfapplets_cps_84585.zip
 cpsid_84585.cfapplets_cps_84585.zip.sha-512=0a4cdab9f8acc126004bbe088fda33dcb70183a11d5e1dd122c660add365c9c63f7fe168b5380d1233a7aa5dec6cf032542a81640d39d8abc322b35dd47a710b
 
 cpsid_86589.description=Deadlock caused by compiler and cache lock for ColdFusion 8.0.1 (hf801-76563)
-cpsid_86589.url=http://kb2.adobe.com/cps/865/cpsid_86589/attachments/
+cpsid_86589.url=http://helpx.adobe.com/content/dam/kb/en/865/cpsid_86589/attachments/
 cpsid_86589.files=hf801-76563.zip
 cpsid_86589.hf801-76563.zip.sha-512=87e66dbcc2a9eb426e05e67b6bf83712b3aeb0c666b484b1141fd9f7e90a0d2e3984d0a2e33365efef9aca7508398c4bfbccc12cb506c228df2149afaea26179
 
 cpsid_90784.description=Security update: Hotfix available for ColdFusion 8.0.1 (APSB11-14)
-cpsid_90784.url=http://kb2.adobe.com/cps/907/cpsid_90784/attachments/
+cpsid_90784.url=http://helpx.adobe.com/content/dam/kb/en/907/cpsid_90784/attachments/
 cpsid_90784.files=CF801.zip,CFIDE-801.zip
 cpsid_90784.CF801.zip.sha-512=c4853aaf0844e031e969763f816bb5485cacfc855d4f77352eee8964d739efb72081242522205fe6a64b565a50825d31e685179ac350da8bb9cf1396a1adf3da
 cpsid_90784.CFIDE-801.zip.sha-512=50f96562ef75f390d879e1980654c0feeb45a7a5d7c84ca1f31917d45c7bad3bdeedfefe54adb68f9f2b87313a044dc20b33ac3216ca8349c99d7939c42fbf3c
 
 cpsid_91836.description=Cumulative Hot Fix 2 (CHF2) for ColdFusion 9.0.1
-cpsid_91836.url=http://kb2.adobe.com/cps/918/cpsid_91836/attachments/
+cpsid_91836.url=http://helpx.adobe.com/content/dam/kb/en/918/cpsid_91836/attachments/
 cpsid_91836.files=CF901.zip,CFIDE-901.zip
 cpsid_91836.CF901.zip.sha-512=064ee66916decf7bbdad991f572c97496fdec7ac747f0c728ec4fcf249a3f01e85e11cf70026fc5d6f106aecddf1ad156043e1c838dc447439d7b838e2e2e499
 cpsid_91836.CFIDE-901.zip.sha-512=70848c608769d7bcdc672ee3a0fa6fac395a43b55f0f11519e1bdc28d05640658b8c1d3276aee31ebab619aa115a52259c0c323250facd865d75d42b85cf0102
 
 cpsid_92512.description=Security update: Hotfix available for ColdFusion 8.0.1 & 9.0.1 (APSB11-29)
-cpsid_92512.url=http://kb2.adobe.com/cps/925/cpsid_92512/attachments/
+cpsid_92512.url=http://helpx.adobe.com/content/dam/kb/en/925/cpsid_92512/attachments/
 cpsid_92512.files=CF801jar.zip,CF901jar.zip
 cpsid_92512.CF801jar.zip.sha-512=fa872cdd7d6848bfb229675be659845533a09f36ff5961df8a6ad462fab1f3ae8eb64aa31fab24a42dfd041aaa5bf892575582581d557fadc05fe51449d023f7
 cpsid_92512.CF901jar.zip.sha-512=314d4cc4dda6ca10782b444ddce2d2fca0c18d393ee9e6f53aa27fddef0ca48989afbe175ea4280f36f99f41605cbdf5ac7182b43de1b59e6f6e6ccab7ccd321


### PR DESCRIPTION
I tried using the latest version of unofficial-updater2 to patch some CF servers but it failed during the download_hotfixes target. I looked at the error messages and found that the URLs for some of the hotfixes now give a 404 error on Adobe's site.

I browsed the Adobe bulletins for the failed downloads and found new URLs for them. Updating `cf_hotfixes.properties` with these new locations allowed the `download_hotfixes` target to succeed.

I haven't figured out how to build Unofficial-Updater2-with-downloads.jar outside of the installer yet so if you could accept this pull request and update the download so I can patch my servers I would appreciate it :-)
